### PR TITLE
Fixes DOM security messages

### DIFF
--- a/client/default.html
+++ b/client/default.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>default html</title>
+        <title></title>
     </head>
     <body>
     </body>

--- a/client/phantom-client.js
+++ b/client/phantom-client.js
@@ -5,7 +5,6 @@
 // this is a phantomjs script. NOT a node script.
 var webpage = require('webpage')
   , system = require('system')
-  , fs = require('fs')
 
 var page = webpage.create()
   , js = system.stdin.read()
@@ -16,10 +15,19 @@ page.onError = onError
 
 phantom.onError = onError
 
-page.content = fs.read(system.args[0])
+page.open(system.args[1], function(stat) {
+  if(stat !== 'success') {
+    system.stderr.write(
+        'Phantom cannot open requested html file: "' + system.args[1] + '"'
+    )
+    phantom.exit(1)
 
-// this function executes `run` in a sandbox, we pass it the js string
-page.evaluateAsync(run, 0, js)
+    return
+  }
+
+  // this function executes `run` in a sandbox, we pass it the js string
+  page.evaluateAsync(run, 0, js)
+})
 
 function onError(msg, trace) {
   var error = {

--- a/test/fixtures/get-title.js
+++ b/test/fixtures/get-title.js
@@ -1,0 +1,1 @@
+console.log(document.querySelector('title').textContent)

--- a/test/fixtures/test.html
+++ b/test/fixtures/test.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>default html</title>
+        <title>test html</title>
     </head>
     <body>
     </body>

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 var fs = require('fs')
-  , exec = require('child_process').exec
 
 var test = require('tape')
   , through = require('through')
@@ -23,6 +22,30 @@ test('executes simple js', function(t) {
 
   p.stdout.pipe(concat(function(data) {
     t.equal(data.toString(), 'simple test\n', 'output should match')
+  }))
+
+  lib(options, p, done)
+
+  function done(code) {
+    t.equal(code, 0, 'exit code should be clean')
+  }
+})
+
+test('loads the requested html file', function(t) {
+  t.plan(2)
+
+  var js = fs.createReadStream('./test/fixtures/get-title.js')
+    , p = makeProcessObject()
+
+  var options = {
+      input: js
+    , html: './test/fixtures/test.html'
+    , phantomPath: phantom.path
+    , timeout: 10
+  }
+
+  p.stdout.pipe(concat(function(data) {
+    t.equal(data.toString(), 'test html\n', 'should get page title')
   }))
 
   lib(options, p, done)


### PR DESCRIPTION
- Turns out we weren't actually loading the html we thought we were;
  that's corrected and a test is added for it.
- Opens the page rather than just replacing the content on
  'about:blank', avoiding SECURITY_ERR issues
