### PR TITLE
Export the correct file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ghostface",
   "version": "1.1.0",
   "description": "Evaluate Javascript in PhantomJS, and print the output.",
-  "main": "index.js",
+  "main": "./lib/index.js",
   "bin": {
     "ghostface": "./bin/ghostface.js"
   },
@@ -25,7 +25,7 @@
   "contributors": [
     "Andrew Winterman <andywinterman@gmail.com>"
   ],
-  "license": "APACHE-2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/fardog/ghostface/issues"
   },


### PR DESCRIPTION
- Although `ghostface` wasn't necessarily meant to be used
  programmatically, you absolutely _could_ use it as such. This corrects
  the package.json to export the correct file.
- Updates the license to the OSI standard license name.
