### PR TITLE
Report to stderr when phantom exited abnormally

### DIFF
--- a/bin/ghostface.js
+++ b/bin/ghostface.js
@@ -8,7 +8,14 @@ var cli = require('../lib/cli')
 
 var error = chalk.bold.red
 
-cli(process.argv.slice(2), function(err, message, options) {
+module.exports = {
+    exit: onExit
+  , cli: onCli
+}
+
+cli(process.argv.slice(2), onCli)
+
+function onCli(err, message, options) {
   if(err) {
     console.error(
         error(
@@ -27,7 +34,13 @@ cli(process.argv.slice(2), function(err, message, options) {
     return
   }
 
-  lib(options, process, function(code) {
-    process.exit(code)
-  })
-})
+  lib(options, process, onExit)
+}
+
+function onExit(code, signal) {
+  if(code > 0) {
+    console.error(sprintf('\nphantomjs exited abnormally: %d'), code)
+  }
+
+  process.exit(code || signal === 'SIGTERM' ? 0 : 1)
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ function phantomEval(options, io, _next) {
   function onExit(code, signal) {
     dead = true
 
-    next(code || (signal === 'SIGTERM' ? 0 : 1))
+    next(code, signal)
   }
 
   // TODO: this section requires significant cleanup

--- a/test/index.js
+++ b/test/index.js
@@ -26,8 +26,8 @@ test('executes simple js', function(t) {
 
   lib(options, p, done)
 
-  function done(code) {
-    t.equal(code, 0, 'exit code should be clean')
+  function done(code, signal) {
+    t.equal(signal, 'SIGTERM', 'should have been terminated')
   }
 })
 
@@ -50,8 +50,8 @@ test('loads the requested html file', function(t) {
 
   lib(options, p, done)
 
-  function done(code) {
-    t.equal(code, 0, 'exit code should be clean')
+  function done(code, signal) {
+    t.equal(signal, 'SIGTERM', 'should have been terminated')
   }
 })
 
@@ -74,8 +74,8 @@ test('executes fibonacci for some reason', function(t) {
 
   lib(options, p, done)
 
-  function done(code) {
-    t.equal(code, 0, 'exit code should be clean')
+  function done(code, signal) {
+    t.equal(signal, 'SIGTERM', 'should have been terminated')
   }
 })
 
@@ -107,7 +107,7 @@ test('fails and sets correct exit code', function(t) {
 
   lib(options, p, done)
 
-  function done(code) {
+  function done(code, signal) {
     p.stderr.write(null)
     t.equal(code, 1, 'exit code should not be clean')
   }
@@ -134,8 +134,8 @@ test('handles timeouts when set', function(t) {
 
   lib(options, p, done)
 
-  function done(code) {
-    t.equal(code, 0, 'exit code should be clean')
+  function done(code, signal) {
+    t.equal(signal, 'SIGTERM', 'should have been terminated')
   }
 })
 


### PR DESCRIPTION
Right now, it's ambiguous if there was an error, or if the timeout was just reached (which is not an error). This reports the error code to stderr with a `phantom exited abnormally` message, rather than just exiting with the error code. Addresses #9 
